### PR TITLE
Use error for invalid DisplayKind in `show`

### DIFF
--- a/src/jupyternimpkg/display.nim
+++ b/src/jupyternimpkg/display.nim
@@ -105,7 +105,7 @@ template show*(kind:DisplayKind, what:untyped) =
   elif kind == dkPlot:
     content = showBase64StringPng(what, size[0], size[1])
   else:
-    echo "Unsupported kind for show ", kind
+    {.error: "Unsupported kind for show: " & $kind.}
   
   stdout.write(startmarker, $content, endmarker)
   stdout.flushFile()


### PR DESCRIPTION
using dkHtml in `show` gave this 
```
Unsupported kind for show dkHtml
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```
which while says the issue, also gives a nil access error that I found to be confusing. This PR uses the `{.error.}` pragma instead
so that a compile time error is thrown instead 